### PR TITLE
Adds install_all that will install prefs for all installed IDEs

### DIFF
--- a/cli/bin/ide_prefs
+++ b/cli/bin/ide_prefs
@@ -29,7 +29,7 @@ OptionParser.new do |opts|
       ["webstorm", "intellij", "intellijcommunity", "rubymine", "appcode", "androidstudio", "clion", "pycharm", "goland"],
       "webstorm, intellij, intellijcommunity, rubymine, appcode, androidstudio", "clion", "pycharm", "goland"
   ) do |ide|
-    repo_config_options[:user_prefs_repo_location] = Module.const_get("Cli::Ide::#{ide.capitalize}UserPrefDir").new.path
+    repo_config_options[:user_prefs_repo_location] = Module.const_get("Cli::Ide::#{ide.capitalize}").new.path
     repo_config_options[:ide_name] = ide
   end
 

--- a/cli/bin/install_all
+++ b/cli/bin/install_all
@@ -1,0 +1,50 @@
+#!/usr/bin/env ruby
+
+unless RUBY_VERSION.to_i >= 2
+  puts "You must use ruby 2.0.0 or greater. OS X Mavericks and beyond ship with Ruby 2+ as the system ruby."
+  exit 1
+end
+
+bin_dir = File.dirname(__FILE__)
+root_dir = File.join(bin_dir, '..', '..')
+
+$LOAD_PATH.unshift "#{root_dir}/ide_prefs/lib"
+$LOAD_PATH.unshift "#{root_dir}/persistence/lib"
+$LOAD_PATH.unshift "#{root_dir}/logging/lib"
+$LOAD_PATH.unshift "#{root_dir}/cli/lib"
+
+require "optparse"
+require "ide_prefs"
+require "persistence"
+require "cli"
+
+installed_ides = Cli::Ide::Finder.new.installed_ide_klasses
+
+if installed_ides.empty?
+  puts "No JetBrains IDEs found installed. Please install at least one and re-run."
+  exit 1
+end
+
+repo_config_options = {}
+logging_options = { log_level: :info }
+
+installed_ides.each do |ide_pref_dir_class|
+  prefs_dir = ide_pref_dir_class.new
+  repo_config_options[:user_prefs_repo_location] = prefs_dir.path
+  repo_config_options[:ide_name] = ide
+
+  Cli::Logger.new(log_level: logging_options[:log_level]).start
+
+  repo_configuration = Cli::Configuration::RepoConfiguration.new(repo_config_options)
+
+  puts "Installing preferences for #{prefs_dir.ide_pref_dir_name_without_version}"
+  puts " - Preferences will install to #{repo_configuration.user_prefs_repo_location}"
+  puts " - Backups will be placed in #{repo_configuration.backup_prefs_repo_location}"
+
+  repos = {
+    user_prefs_repo: Persistence::Repos::UserPrefsRepo.new(location: repo_configuration.user_prefs_repo_location),
+    backup_prefs_repo: Persistence::Repos::BackupPrefsRepo.new(location: repo_configuration.backup_prefs_repo_location),
+    pivotal_prefs_repo: Persistence::Repos::PivotalPrefsRepo.new(location: repo_configuration.pivotal_prefs_repo_location),
+  }
+  Cli::CommandFactory.new("install").command.new(repos).execute
+end

--- a/cli/lib/cli/ide/androidstudio.rb
+++ b/cli/lib/cli/ide/androidstudio.rb
@@ -1,8 +1,11 @@
-require "cli/ide/jet_brains_ide_user_pref_dir"
-
+require "cli/ide/jet_brains_ide"
 module Cli
   module Ide
-    class AndroidstudioUserPrefDir < JetBrainsIdeUserPrefDir
+    class Androidstudio < JetBrainsIde
+      def self.bundle_name
+        "Android Studio.app"
+      end
+
       def ide_pref_dir_name_without_version
         "AndroidStudio"
       end

--- a/cli/lib/cli/ide/appcode.rb
+++ b/cli/lib/cli/ide/appcode.rb
@@ -1,8 +1,12 @@
-require 'cli/ide/jet_brains_ide_user_pref_dir'
+require 'cli/ide/jet_brains_ide'
 
 module Cli
   module Ide
-    class AppcodeUserPrefDir < JetBrainsIdeUserPrefDir
+    class Appcode < JetBrainsIde
+      def self.bundle_name
+        "AppCode.app"
+      end
+
       def ide_pref_dir_name_without_version
         'AppCode'
       end

--- a/cli/lib/cli/ide/clion.rb
+++ b/cli/lib/cli/ide/clion.rb
@@ -1,8 +1,12 @@
-require 'cli/ide/jet_brains_ide_user_pref_dir'
+require 'cli/ide/jet_brains_ide'
 
 module Cli
   module Ide
-    class ClionUserPrefDir < JetBrainsIdeUserPrefDir
+    class Clion < JetBrainsIde
+      def self.bundle_name
+        "CLion.app"
+      end
+
       def ide_pref_dir_name_without_version
         'CLion'
       end

--- a/cli/lib/cli/ide/finder.rb
+++ b/cli/lib/cli/ide/finder.rb
@@ -1,0 +1,45 @@
+module Cli
+  module Ide
+    class Finder
+      attr_reader :available_ides
+
+      def initialize
+        @ide_map = ide_klasses.each_with_object({}) do |klass, map|
+          map[klass.bundle_name] = klass
+        end
+        @available_ides = @ide_map.keys
+      end
+
+      def installed_apps
+        @installed_apps ||= Dir.chdir(File.join("/", "Applications")) { Dir.glob("*.app") }
+      end
+
+      def installed_ide_klasses
+        available_ides.reduce([]) do |ide_klasses, ide|
+          if installed_apps.include?(ide)
+            ide_klasses << @ide_map[ide]
+          end
+          ide_klasses
+        end
+      end
+
+      private
+
+      def ide_klasses
+        @ide_klasses ||= Cli::Ide.constants.reduce([]) do |klasses, c|
+          k = Cli::Ide.const_get(c)
+          if k.is_a? Class and an_included_class(k)
+            klasses << k
+          end
+          klasses
+        end
+      end
+
+      def an_included_class(k)
+        k != Finder and
+          k != JetBrainsIde and
+          k != PreferencesDirectory
+      end
+    end
+  end
+end

--- a/cli/lib/cli/ide/goland.rb
+++ b/cli/lib/cli/ide/goland.rb
@@ -1,10 +1,13 @@
-require "cli/ide/jet_brains_ide_user_pref_dir"
-
+require "cli/ide/jet_brains_ide"
 module Cli
   module Ide
-    class IntellijUserPrefDir < JetBrainsIdeUserPrefDir
+    class Goland < JetBrainsIde
+      def self.bundle_name
+        "GoLand.app"
+      end
+
       def ide_pref_dir_name_without_version
-        "IntelliJIdea"
+        "GoLand"
       end
 
       def default_ide_pref_dir_version

--- a/cli/lib/cli/ide/intellij.rb
+++ b/cli/lib/cli/ide/intellij.rb
@@ -1,10 +1,13 @@
-require "cli/ide/jet_brains_ide_user_pref_dir"
-
+require "cli/ide/jet_brains_ide"
 module Cli
   module Ide
-    class GolandUserPrefDir < JetBrainsIdeUserPrefDir
+    class Intellij < JetBrainsIde
+      def self.bundle_name
+        "IntelliJ IDEA.app"
+      end
+
       def ide_pref_dir_name_without_version
-        "GoLand"
+        "IntelliJIdea"
       end
 
       def default_ide_pref_dir_version

--- a/cli/lib/cli/ide/intellijcommunity.rb
+++ b/cli/lib/cli/ide/intellijcommunity.rb
@@ -1,10 +1,13 @@
-require "cli/ide/preferences_directory"
-
+require "cli/ide/jet_brains_ide"
 module Cli
   module Ide
-    class RubymineUserPrefDir < JetBrainsIdeUserPrefDir
+    class Intellijcommunity < JetBrainsIde
+      def self.bundle_name
+        "IntelliJ IDEA CE.app"
+      end
+
       def ide_pref_dir_name_without_version
-        "RubyMine"
+        "IdeaIC"
       end
 
       def default_ide_pref_dir_version

--- a/cli/lib/cli/ide/jet_brains_ide.rb
+++ b/cli/lib/cli/ide/jet_brains_ide.rb
@@ -2,7 +2,7 @@ require "cli/ide/preferences_directory"
 
 module Cli
   module Ide
-    class JetBrainsIdeUserPrefDir
+    class JetBrainsIde
       def path
         preferences_directory = File.expand_path(File.join("~", "Library", "Application Support", "Jetbrains"))
 

--- a/cli/lib/cli/ide/pycharm.rb
+++ b/cli/lib/cli/ide/pycharm.rb
@@ -1,8 +1,11 @@
-require "cli/ide/jet_brains_ide_user_pref_dir"
-
+require "cli/ide/jet_brains_ide"
 module Cli
   module Ide
-    class PycharmUserPrefDir < JetBrainsIdeUserPrefDir
+    class Pycharm < JetBrainsIde
+      def self.bundle_name
+        "PyCharm.app"
+      end
+
       def ide_pref_dir_name_without_version
         "PyCharm"
       end

--- a/cli/lib/cli/ide/rubymine.rb
+++ b/cli/lib/cli/ide/rubymine.rb
@@ -1,10 +1,14 @@
-require "cli/ide/jet_brains_ide_user_pref_dir"
+require "cli/ide/preferences_directory"
 
 module Cli
   module Ide
-    class IntellijcommunityUserPrefDir < JetBrainsIdeUserPrefDir
+    class Rubymine < JetBrainsIde
+      def self.bundle_name
+        "RubyMine.app"
+      end
+
       def ide_pref_dir_name_without_version
-        "IdeaIC"
+        "RubyMine"
       end
 
       def default_ide_pref_dir_version

--- a/cli/lib/cli/ide/webstorm.rb
+++ b/cli/lib/cli/ide/webstorm.rb
@@ -1,8 +1,11 @@
-require "cli/ide/jet_brains_ide_user_pref_dir"
-
+require "cli/ide/jet_brains_ide"
 module Cli
   module Ide
-    class WebstormUserPrefDir < JetBrainsIdeUserPrefDir
+    class Webstorm < JetBrainsIde
+      def self.bundle_name
+        "WebStorm.app"
+      end
+
       def ide_pref_dir_name_without_version
         "WebStorm"
       end

--- a/cli/spec/cli/ide/finder_spec.rb
+++ b/cli/spec/cli/ide/finder_spec.rb
@@ -1,0 +1,11 @@
+module Cli::Ide
+  describe Finder do
+    let(:finder) { Finder.new }
+
+    describe "#available_ides" do
+      it "knows about all of the available IDE classes" do
+        expect(finder.available_ides.size).to eq(9)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- I've renamed the PrefsDir classes because they now know more than just their prefs dir paths
- I've added a new class called `Cli::Ide::Finder` that discovers all the IDEs that we know about that are also installed.
  - Not thrilled with the testing of it at the moment, but everything I wrote was a bit of a tautology
- `install_all` uses the new `Finder` class to get the class for each IDE and then installs the prefs for it