### PR TITLE
Fix callsites of hash initialisers to work with ruby 3

### DIFF
--- a/cli/bin/ide_prefs.rb
+++ b/cli/bin/ide_prefs.rb
@@ -53,7 +53,7 @@ end
 
 Cli::Logger.new(log_level: logging_options[:log_level]).start
 
-repo_configuration = Cli::Configuration::RepoConfiguration.new(repo_config_options)
+repo_configuration = Cli::Configuration::RepoConfiguration.new(**repo_config_options)
 
 puts "This will install preferences at #{repo_configuration.user_prefs_repo_location}"
 puts "And store backups at #{repo_configuration.backup_prefs_repo_location}"
@@ -64,4 +64,4 @@ repos = {
   pivotal_prefs_repo: Persistence::Repos::PivotalPrefsRepo.new(location: repo_configuration.pivotal_prefs_repo_location),
 }
 
-Cli::CommandFactory.new(ARGV.last).command.new(repos).execute
+Cli::CommandFactory.new(ARGV.last).command.new(**repos).execute


### PR DESCRIPTION
Hey friends. I'm not sure if this repo is still considered under active development, but  I'd sure like to be able to 
run this through `workstation-setup`. 

I recently had the occasion to image a new workstation, and ran the pivotal-legacy workstation setup. It installs the latest version of ruby (which as of this writing is 3.0.2), which is incompatible with some of the scripts here, because of a breaking change in how ruby v3.0 supports constructors called with hash literals, but which internally expect to receive named parameters.

I saw that the pivotal-legacy repo is considered deprecated, so thought that I would make this PR to improve this repo. Happy to re-issue this if there's a better place for this work to land, or if you see any other changes. Since this was on the very outside of the repo (in the bin scripts) I didn't see the need for any tests to change, but I could see the need for some tests to make sure this doesn't regress again - it took me an at least an hour to find the breaking changes for ruby 3 and identify how to fix it.